### PR TITLE
feat: Cleanup stale tokens from database

### DIFF
--- a/db.go
+++ b/db.go
@@ -243,3 +243,10 @@ func (d *DB) VerificationRole(guild discord.GuildID) (discord.RoleID, bool, erro
 	}
 	return role, true, nil
 }
+
+// Cleanup removes all tokens that are older than 5 minutes.
+func (d *DB) CleanupTokens() error {
+	s := "DELETE FROM tokens WHERE created_at < NOW() - INTERVAL '5 minutes'"
+	_, err := d.db.Exec(s)
+	return err
+}


### PR DESCRIPTION
This PR adds a feature to remove stale tokens.
It is implemented by running spinning up a goroutine which runs every 5 minutes to remove tokens which are older than 5 minutes. 
When the program exits, it kills the goroutine.