### PR TITLE
feat: Support multiple verification domains per guild

### DIFF
--- a/command.go
+++ b/command.go
@@ -11,7 +11,13 @@ import (
 )
 
 func Register(s *state.State, editResponse func(string) error, user discord.UserID, guild discord.GuildID, email string) (string, error) {
-	domain, ok, err := db.EmailDomain(guild)
+	domain, err := extractDomain(email)
+	if err != nil {
+		return "Bad formatting of email. Make sure it is correctly typed in and try again.", fmt.Errorf("error extracting domain: %w", err)
+	}
+	// check if the email is configured for verification
+	role, ok, err := db.GetConfig(guild, domain)
+
 	if err != nil {
 		return "", fmt.Errorf("failed to get email domain from DB: %w", err)
 	} else if !ok {
@@ -22,18 +28,19 @@ func Register(s *state.State, editResponse func(string) error, user discord.User
 		return err.Error(), nil
 	}
 
-	hashedEmail, err := MakeIdentifier(guild, email)
+	id, err := MakeIdentifier(guild, email)
 	if err != nil {
 		return "", fmt.Errorf("failed making an identifier from the email: %w", err)
 	}
 
 	// skip registration if account should already be verified
-	userID, ok, err := db.GetVerifiedEmail(guild, hashedEmail)
+	userID, ok, err := db.GetVerifiedEmail(guild, id)
 	if err != nil {
 		return "", fmt.Errorf("error getting user ID from DB during registration: %w", err)
 	}
+
 	if ok && userID == user {
-		ok, err := addVerifiedRole(s, guild, user)
+		ok, err := addVerifiedRole(s, guild, user, role)
 		if err != nil {
 			return "", fmt.Errorf("couldn't verify user: %w", err)
 		} else if !ok {
@@ -44,7 +51,7 @@ func Register(s *state.State, editResponse func(string) error, user discord.User
 
 	// create random token
 	token := MakeToken()
-	err = db.SetEmailToken(guild, hashedEmail, token)
+	err = db.SetEmailToken(guild, id, token, role)
 	if err != nil {
 		return "", fmt.Errorf("error setting token in DB: %v", err)
 	}
@@ -93,7 +100,7 @@ func Verify(s *state.State, user discord.UserID, guild discord.GuildID, tokenStr
 	// message may have multiple lines so we use a string builder
 	msg := &strings.Builder{}
 
-	email, ok, err := db.GetEmailToken(guild, token)
+	id, role, ok, err := db.GetEmailToken(guild, token)
 	if err != nil {
 		return "", fmt.Errorf("error getting token from db: %w", err)
 	}
@@ -102,7 +109,7 @@ func Verify(s *state.State, user discord.UserID, guild discord.GuildID, tokenStr
 	}
 
 	// put ban check after verification to prevent banned email enumeration
-	banned, err := db.IsBanned(guild, email)
+	banned, err := db.IsBanned(guild, id)
 	if err != nil {
 		return "", fmt.Errorf("error checking if user is banned: %w", err)
 	}
@@ -111,14 +118,15 @@ func Verify(s *state.State, user discord.UserID, guild discord.GuildID, tokenStr
 	}
 
 	// we'll use to unverify the old user after verifying the new one
-	oldUser, hasOldUser, err := db.GetVerifiedEmail(guild, email)
+	oldUser, hasOldUser, err := db.GetVerifiedEmail(guild, id)
 	if err != nil {
 		return "", fmt.Errorf("error getting user from db: %w", err)
 	}
 
 	// must remove old user before adding new one for UNIQUE constraint
 	if hasOldUser {
-		ok, err := removeVerifiedRole(s, guild, oldUser)
+		// remove old user's verified role
+		ok, err := removeVerifiedRole(s, guild, oldUser, id)
 		if err != nil {
 			oldUser, _ := s.User(oldUser)
 			return "", fmt.Errorf("error removing verified user: %v#%v", oldUser.Username, oldUser.Discriminator)
@@ -127,14 +135,15 @@ func Verify(s *state.State, user discord.UserID, guild discord.GuildID, tokenStr
 		} else {
 			fmt.Fprintf(msg, "Your email was also used to verify <@%v>. That account has been unverified.\n", oldUser)
 		}
-		err = db.DeleteVerifiedUser(guild, oldUser)
+
+		err = db.DeleteVerifiedEmail(guild, id)
 		if err != nil {
 			return "", fmt.Errorf("error removing verified user from db: %w", err)
 		}
 
 	}
 
-	ok, err = addVerifiedRole(s, guild, user)
+	ok, err = addVerifiedRole(s, guild, user, role)
 	if err != nil {
 		return "", fmt.Errorf("couldn't verify user: %w", err)
 	} else if !ok {
@@ -145,7 +154,7 @@ func Verify(s *state.State, user discord.UserID, guild discord.GuildID, tokenStr
 	if err != nil {
 		return "", fmt.Errorf("error deleting token in DB: %w", err)
 	}
-	err = db.SetVerifiedEmail(guild, email, user)
+	err = db.SetVerifiedEmail(guild, id, user, role)
 	if err != nil {
 		return "", fmt.Errorf("error verifying user in DB: %w", err)
 	}
@@ -155,18 +164,13 @@ func Verify(s *state.State, user discord.UserID, guild discord.GuildID, tokenStr
 	return strings.TrimSpace(msg.String()), nil
 }
 
-func addVerifiedRole(s *state.State, guild discord.GuildID, user discord.UserID) (bool, error) {
-	role, ok, err := db.VerificationRole(guild)
-	if err != nil {
-		return false, err
-	} else if !ok {
-		return false, nil
-	}
+func addVerifiedRole(s *state.State, guild discord.GuildID, user discord.UserID, role discord.RoleID) (bool, error) {
 	return true, s.AddRole(guild, user, role, api.AddRoleData{AuditLogReason: api.AuditLogReason("Gatekeeper verification")})
 }
 
-func removeVerifiedRole(s *state.State, guild discord.GuildID, user discord.UserID) (bool, error) {
-	role, ok, err := db.VerificationRole(guild)
+func removeVerifiedRole(s *state.State, guild discord.GuildID, user discord.UserID, id Identifier) (bool, error) {
+	// at the moment a user can only have a single verified role for a single domain
+	role, ok, err := db.VerificationRole(guild, id)
 	if err != nil {
 		return false, err
 	} else if !ok {
@@ -176,45 +180,40 @@ func removeVerifiedRole(s *state.State, guild discord.GuildID, user discord.User
 }
 
 func Ban(s *state.State, user discord.UserID, guild discord.GuildID) (string, error) {
-	email, ok, err := db.GetUserEmail(guild, user)
+	// a user can potentially have multiple verified roles for multiple domains in a single guild
+	identifiers, err := db.GetUserIdentifiers(guild, user)
 	if err != nil {
 		return "", fmt.Errorf("error getting identifier from DB: %w", err)
 	}
-	if !ok {
+
+	if len(identifiers) == 0 {
 		return fmt.Sprintf("Error: user <@%v> not verified", user), nil
 	}
-	err = db.BanEmail(guild, email)
-	if err != nil {
-		return "", fmt.Errorf("error banning id in DB: %w", err)
-	}
 
-	ok, err = removeVerifiedRole(s, guild, user)
-	if err != nil {
-		return "", fmt.Errorf("couldn't unverify user: %w", err)
-	} else if !ok {
-		return "You need to configure the verified role first, ask your admins to set it up.", err
-	}
-	err = db.DeleteVerifiedEmail(guild, email)
-	if err != nil {
-		return "", fmt.Errorf("error unverifying user in DB: %w", err)
-	}
+	for _, id := range identifiers {
+		err = db.BanEmail(guild, id)
+		if err != nil {
+			return "", fmt.Errorf("error banning id in DB: %w", err)
+		}
 
+		ok, err := removeVerifiedRole(s, guild, user, id)
+		if err != nil {
+			return "", fmt.Errorf("couldn't unverify user: %w", err)
+		} else if !ok {
+			return "You need to configure the verified role first, ask your admins to set it up.", err
+		}
+		err = db.DeleteVerifiedEmail(guild, id)
+		if err != nil {
+			return "", fmt.Errorf("error unverifying user in DB: %w", err)
+		}
+	}
 	return fmt.Sprintf("Success! User <@%v> was banned.", user), nil
 }
 
 func Config(s *state.State, guild discord.GuildID, domain string, role discord.RoleID) (string, error) {
-	if has, err := db.HasConfig(guild); err != nil {
-		return "", err
-	} else if has {
-		err := db.UpdateConfig(guild, domain, role)
-		if err != nil {
-			return "", err
-		}
-	} else {
-		err := db.MakeConfig(guild, domain, role)
-		if err != nil {
-			return "", err
-		}
+	err := db.UpdateConfig(guild, domain, role)
+	if err != nil {
+		return "", fmt.Errorf("error updating config in DB: %w", err)
 	}
 	return "Successfully updated config!", nil
 }

--- a/command.go
+++ b/command.go
@@ -51,7 +51,7 @@ func Register(s *state.State, editResponse func(string) error, user discord.User
 
 	// create random token
 	token := MakeToken()
-	err = db.SetEmailToken(guild, id, token, role)
+	err = db.SetEmailToken(guild, id, token, domain)
 	if err != nil {
 		return "", fmt.Errorf("error setting token in DB: %v", err)
 	}

--- a/email.go
+++ b/email.go
@@ -50,3 +50,17 @@ func validateEmail(domain, email string) error {
 
 	return nil
 }
+
+func extractDomain(email string) (string, error) {
+	address, err := mail.ParseAddress(email)
+	if err != nil {
+		return "", fmt.Errorf("email address format is invalid")
+	}
+
+	parts := strings.Split(address.Address, "@")
+	if len(parts) != 2 {
+		return "", fmt.Errorf("email address format is invalid")
+	}
+
+	return parts[1], nil
+}

--- a/migrations/init.sql
+++ b/migrations/init.sql
@@ -16,8 +16,9 @@ CREATE TABLE token (
 	guild BIGINT NOT NULL,
 	token BINARY(8) NOT NULL,
 	identifier BINARY(32) NOT NULL,
-	verification_role BIGINT NOT NULL,
+	email_domain VARCHAR(255) NOT NULL,
 	created_at DATE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	FOREIGN KEY (guild, email_domain) REFERENCES config (guild, email_domain),
 	PRIMARY KEY (guild, token)
 );
 

--- a/migrations/init.sql
+++ b/migrations/init.sql
@@ -1,19 +1,26 @@
+-- NOTE: Make sure to read up on "Datatypes in SQLite" before you start writing
+--       your own migrations. The SQLite documentation is available online at
+--       https://www.sqlite.org/datatype3.html
 CREATE TABLE verified (
 	guild BIGINT NOT NULL,
 	identifier BINARY(32) NOT NULL,
+	verification_role BIGINT NOT NULL,
 	user BIGINT NOT NULL,
 	UNIQUE(identifier, user),
 	PRIMARY KEY (guild, identifier)
 );
+
 CREATE INDEX verified_user_index on verified (guild, user);
 
 CREATE TABLE token (
 	guild BIGINT NOT NULL,
 	token BINARY(8) NOT NULL,
 	identifier BINARY(32) NOT NULL,
+	verification_role BIGINT NOT NULL,
 	created_at DATE NOT NULL DEFAULT CURRENT_TIMESTAMP,
 	PRIMARY KEY (guild, token)
 );
+
 CREATE INDEX tokens_created_at_index on token (created_at);
 
 CREATE TABLE banned (
@@ -26,5 +33,6 @@ CREATE TABLE config (
 	guild BIGINT NOT NULL,
 	email_domain VARCHAR(255) NOT NULL,
 	verification_role BIGINT NOT NULL,
-	PRIMARY KEY (guild)
+	UNIQUE (guild, email_domain),
+	PRIMARY KEY (guild, email_domain)
 );


### PR DESCRIPTION
This PR adds the ability for a single guild (Discord server) to support verifications on multiple domains.

Notables Changes
* A guild can configure multiple domains now. The mapping is 1:1 and scoped at the guild level.
* When a token is created, it now has a `role` associated with it. This value is used to add the role to a server when they verify.
    * If the server admin updates the role associated with a domain while a token is still unused and not stale, they will receive the old role.  
* The application now tracks `role` a user has when verified, banned or unverified (via. another user requesting verification). The concerns of this additional data are minimal given a users role assignment is already public information within the guild.
* When a user is banned from a guild, all their roles are removed and all their identifiers are added to the ban list for that guild. 